### PR TITLE
Bigger blocksize to avoid core dumps

### DIFF
--- a/aac.c
+++ b/aac.c
@@ -73,7 +73,7 @@ sprintf(filename,"%s-pure-adts.aac",argv[2]);
 FILE *out_aac=fopen(filename,"wb");
 free(filename);
 
-int blocksize=10000000;
+int blocksize=1000000000;
 
 uint8_t *buf=malloc(blocksize);
 uint8_t *tmp=malloc(100000); // 8192+7


### PR DESCRIPTION
When video is big enough there is a core dump when extracting aac audio, with this blocksize it works fine with videos at least 2 minutes duration